### PR TITLE
Changed duplicate checkbox ID

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -29,8 +29,8 @@
     </div>
     <div class="row">
       <div class="field">
-        <input id="lunch" type='checkbox' <%= name_value :lunch, :checkbox %>>
-        <label for="lunch">Lunch? <em>(please give at least 2 days notice)</em></label>
+        <input id="lunch_employee" type='checkbox' <%= name_value :lunch, :checkbox %>>
+        <label for="lunch_employee">Lunch? <em>(please give at least 2 days notice)</em></label>
       </div>
     </div>
   </fieldset>


### PR DESCRIPTION
Clicking on the `Lunch?` label in the employee section checks the lunch checkbox in the guest section due to a duplicate input ID.